### PR TITLE
Credential Type Persistence - Moving from userSession Note to UserModel attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.hadleyso.keycloak</groupId>
   <artifactId>keycloak-qr-code-login</artifactId>
   <packaging>jar</packaging>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.2.1-SNAPSHOT</version>
 
   <name>Keycloak QR Code Login</name>
   <description>QR Code execution extension</description>


### PR DESCRIPTION
Fixes #9 

Moving from from userSession Note to UserModel attribute when handling credential type persistence. Capture type before AuthenticationFlowContext destructs.